### PR TITLE
better filename

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,7 +1,0 @@
-import { describe, it, expect } from 'vitest';
-
-describe('sum test', () => {
-	it('adds 1 + 2 to equal 3', () => {
-		expect(1 + 2).toBe(3);
-	});
-});

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,5 @@
+interface SongsterrDownloadResponse {
+	file: number[];
+	fileName: string;
+	contentType: string;
+}

--- a/src/ui/Form.svelte
+++ b/src/ui/Form.svelte
@@ -6,27 +6,33 @@
 		clearValidationMessage
 	} from '../utils/inputUtils';
 
-	function triggerLinkDownload(generatedUrl: string): void {
-		if (!/\.gp/.test(generatedUrl)) {
-			alert('There was a problem getting the file from this url ):');
+	function triggerLinkDownload(
+		res: SongsterrDownloadResponse | undefined
+	): void {
+		if (!res) {
+			alert('Unable to download the Guitar pro link from this URL ):');
+			return;
 		}
+
+		const uint8Array = new Uint8Array(res.file);
+		const blob = new Blob([uint8Array], { type: res.contentType });
+
 		const link = document.createElement('a');
-		link.href = generatedUrl;
-		document.body.appendChild(link);
+		link.href = window.URL.createObjectURL(blob);
+		link.download = res.fileName;
 		link.click();
-		document.body.removeChild(link);
 	}
 </script>
 
 <form
 	class="flex flex-col items-center"
 	method="POST"
-	action="?/getDownloadLink"
+	action="?/getFileResource"
 	use:enhance={() => {
 		return async ({ result, update }) => {
 			update({ reset: false });
 			// @ts-ignore
-			triggerLinkDownload(result.data);
+			triggerLinkDownload(result?.data);
 		};
 	}}
 >

--- a/src/utils/getDownloadLink.ts
+++ b/src/utils/getDownloadLink.ts
@@ -29,6 +29,14 @@ async function getDownloadLink(
 }
 
 // helpers
+export function buildFileName(url: string, downloadUrl: string): string {
+	const fileName = url.substring(
+		url.lastIndexOf('/') + 1,
+		url.lastIndexOf('-')
+	);
+	const fileType = downloadUrl.endsWith('.gp5') ? '.gp5' : '.gp';
+	return fileName + fileType;
+}
 async function _getParsedContentsFromUrl(
 	url: string,
 	websiteType: 'xml' | 'html'

--- a/src/utils/inputUtils.ts
+++ b/src/utils/inputUtils.ts
@@ -5,6 +5,8 @@ export function setValidationMessage(event: Event): void {
 	} else {
 		input.setCustomValidity('Please enter a valid Songsterr URL.');
 	}
+
+	input.reportValidity();
 }
 export function clearValidationMessage(event: Event): void {
 	const input = event.target as HTMLInputElement;


### PR DESCRIPTION
In order to build the custom filename, I had to do the following
1. download the contents from the backend (`+page.server.svelete`)
1a. check the content-type header from the response to get the filetype (`.gp` / `.gp5`)
2. convert the response to an array buffer, store it as `Array.from(Uint8Array(buffer))` to send to the client.
3. In the client level, and then convert the array to a `Blob`, store the blob contents in the link, then trigger the download.