### PR TITLE
fix: GP7 drum tracks export empty in Guitar Pro

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@coderline/alphatab": "^1.8.1",
         "@xmldom/xmldom": "^0.8.10",
+        "fflate": "^0.8.3",
         "mixpanel-browser": "^2.75.0",
         "pino": "^10.3.1",
       },
@@ -244,6 +245,8 @@
     "@vitest/utils": ["@vitest/utils@3.2.6", "", { "dependencies": { "@vitest/pretty-format": "3.2.6", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg=="],
 
     "@xmldom/xmldom": ["@xmldom/xmldom@0.8.10", "", {}, "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw=="],
+
+    "fflate": ["fflate@0.8.3", "", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
 
     "@xstate/fsm": ["@xstate/fsm@1.6.5", "", {}, "sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw=="],
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@coderline/alphatab": "^1.8.1",
     "@xmldom/xmldom": "^0.8.10",
+    "fflate": "^0.8.3",
     "mixpanel-browser": "^2.75.0",
     "pino": "^10.3.1"
   }

--- a/src/lib/server/services/converter/gp7-percussion-patch.ts
+++ b/src/lib/server/services/converter/gp7-percussion-patch.ts
@@ -1,0 +1,94 @@
+import { unzipSync, zipSync } from 'fflate';
+
+const GPIF_PATH = 'Content/score.gpif';
+
+const INSTRUMENT_SET_PATTERN = /<InstrumentSet>(.*?)<\/InstrumentSet>/gs;
+const ARTICULATION_PATTERN = /<Articulation>.*?<\/Articulation>/gs;
+const OUTPUT_MIDI_PATTERN = /<OutputMidiNumber>(\d+)<\/OutputMidiNumber>/;
+const NOTE_PATTERN = /<Note\b.*?<\/Note>/gs;
+const ARTICULATION_INDEX_PATTERN =
+  /<InstrumentArticulation>(\d+)<\/InstrumentArticulation>/;
+const STRING_PROPERTY = '<Property name="String">';
+
+/**
+ * Guitar Pro places a percussion note on the drum staff only when the note
+ * carries <Fret>/<Midi> properties. alphaTab's Gp7Exporter writes those only
+ * for stringed (and piano) notes, so GP7 drum tracks exported through alphaTab
+ * open as empty in Guitar Pro.
+ *
+ * This patches the exported GPIF, injecting
+ *   <Property name="Fret"><Fret>{midi}</Fret></Property>
+ *   <Property name="Midi"><Number>{midi}</Number></Property>
+ * into every note that references a drum kit articulation (it has an
+ * <InstrumentArticulation> and no String property), where {midi} is the drum
+ * sound's MIDI number declared by the kit articulation's <OutputMidiNumber>.
+ */
+export function patchPercussionNotesInGpif(gpif: string): string {
+  const articulationMidi = buildDrumKitMidiMap(gpif);
+  if (articulationMidi.length === 0) {
+    return gpif;
+  }
+
+  return gpif.replace(NOTE_PATTERN, (note) => {
+    if (note.includes(STRING_PROPERTY)) {
+      return note; // stringed note — already carries Fret/Midi
+    }
+    const articulation = note.match(ARTICULATION_INDEX_PATTERN);
+    if (!articulation) {
+      return note;
+    }
+    const midi = articulationMidi[parseInt(articulation[1], 10)];
+    if (midi == null) {
+      return note;
+    }
+    const properties =
+      `<Property name="Fret"><Fret>${midi}</Fret></Property>` +
+      `<Property name="Midi"><Number>${midi}</Number></Property>`;
+    return note.replace('</Properties>', properties + '</Properties>');
+  });
+}
+
+/**
+ * Maps percussion articulation index → output MIDI number for the file's drum
+ * kit (multi-track files have one InstrumentSet per track, so pick the
+ * drumKit). Returns an empty list when the file has no drum track.
+ */
+function buildDrumKitMidiMap(gpif: string): (number | null)[] {
+  for (const match of gpif.matchAll(INSTRUMENT_SET_PATTERN)) {
+    const instrumentSet = match[1];
+    if (!instrumentSet.includes('<Type>drumKit</Type>')) {
+      continue;
+    }
+    const midiByArticulationIndex: (number | null)[] = [];
+    for (const articulation of instrumentSet.matchAll(ARTICULATION_PATTERN)) {
+      const midi = articulation[0].match(OUTPUT_MIDI_PATTERN);
+      midiByArticulationIndex.push(midi ? parseInt(midi[1], 10) : null);
+    }
+    return midiByArticulationIndex;
+  }
+  return [];
+}
+
+/**
+ * Re-zips an exported GP7 with Fret/Midi injected into percussion notes.
+ * Returns the original bytes untouched when the file has no drum track.
+ */
+export function patchGp7Percussion(gp7: Uint8Array): Uint8Array {
+  const entries = unzipSync(gp7);
+  const gpifBytes = entries[GPIF_PATH];
+  if (!gpifBytes) {
+    return gp7;
+  }
+
+  const gpif = new TextDecoder().decode(gpifBytes);
+  const patched = patchPercussionNotesInGpif(gpif);
+  if (patched === gpif) {
+    return gp7;
+  }
+
+  entries[GPIF_PATH] = new TextEncoder().encode(patched);
+
+  // fflate preserves directory entries (trailing "/") so the re-packed zip
+  // keeps the layout Guitar Pro expects.
+  return zipSync(entries);
+}

--- a/src/lib/server/services/converter/songsterr-to-alphatab.converter.test.ts
+++ b/src/lib/server/services/converter/songsterr-to-alphatab.converter.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
+import { unzipSync } from 'fflate';
 import { SongsterrToAlphaTabConverter } from './songsterr-to-alphatab.converter';
 import type {
   SongsterrRevisionTrackPayload,
@@ -1204,6 +1205,83 @@ describe('SongsterrToAlphaTabConverter', () => {
         (n) => score.tracks[0].percussionArticulations[n.percussionArticulation]?.outputMidiNumber
       );
       expect(new Set(midi)).toEqual(new Set([42, 36, 38]));
+    });
+
+    it('writes Fret/Midi properties on percussion notes (required for Guitar Pro to place them)', () => {
+      // alphaTab's Gp7Exporter writes <Fret>/<Midi> only for stringed notes, so
+      // drum tracks exported straight from it open as EMPTY in Guitar Pro. The
+      // converter patches those properties back in after export.
+      const revision: SongsterrRevisionTrackPayload = {
+        instrumentId: 1024,
+        measures: [
+          {
+            voices: [
+              {
+                beats: [
+                  {
+                    notes: [
+                      { fret: 36, string: 0 }, // kick
+                      { fret: 38, string: 1 }, // snare
+                      { fret: 42, string: 2 } // hi-hat
+                    ],
+                    duration: [1, 4],
+                    type: 4
+                  }
+                ]
+              }
+            ],
+            signature: [4, 4]
+          }
+        ]
+      };
+
+      const meta = makeTrackMeta({
+        instrumentId: 1024,
+        isDrums: true,
+        title: 'Drums',
+        tuning: []
+      });
+      const { data } = new SongsterrToAlphaTabConverter().toGp7({
+        meta: makeMeta([meta]),
+        revisions: [{ trackMeta: meta, revision }]
+      });
+
+      const gpif = new TextDecoder().decode(
+        unzipSync(data)['Content/score.gpif']
+      );
+
+      // articulation index → output MIDI number, from the drum kit
+      const articulationMidi: number[] = [];
+      for (const kit of gpif.matchAll(/<InstrumentSet>(.*?)<\/InstrumentSet>/gs)) {
+        if (!kit[1].includes('<Type>drumKit</Type>')) continue;
+        for (const art of kit[1].matchAll(/<Articulation>.*?<\/Articulation>/gs)) {
+          const m = art[0].match(/<OutputMidiNumber>(\d+)<\/OutputMidiNumber>/);
+          if (m) articulationMidi.push(parseInt(m[1], 10));
+        }
+        break;
+      }
+      expect(articulationMidi).toContain(36);
+      expect(articulationMidi).toContain(38);
+      expect(articulationMidi).toContain(42);
+
+      // Every percussion note must carry Fret/Midi equal to its drum sound
+      let percussionNotes = 0;
+      for (const note of gpif.matchAll(/<Note\b.*?<\/Note>/gs)) {
+        if (note[0].includes('<Property name="String">')) continue;
+        const art = note[0].match(
+          /<InstrumentArticulation>(\d+)<\/InstrumentArticulation>/
+        );
+        if (!art) continue;
+        percussionNotes++;
+        const midi = articulationMidi[parseInt(art[1], 10)];
+        expect(note[0]).toContain(
+          `<Property name="Fret"><Fret>${midi}</Fret></Property>`
+        );
+        expect(note[0]).toContain(
+          `<Property name="Midi"><Number>${midi}</Number></Property>`
+        );
+      }
+      expect(percussionNotes).toBe(3);
     });
   });
 

--- a/src/lib/server/services/converter/songsterr-to-alphatab.converter.ts
+++ b/src/lib/server/services/converter/songsterr-to-alphatab.converter.ts
@@ -11,6 +11,7 @@ import type {
 } from '$lib/types';
 import { mapSongsterrDuration } from './duration-mapper';
 import { mapSongsterrInstrumentToPlayback } from './instrument-map';
+import { patchGp7Percussion } from './gp7-percussion-patch';
 
 export interface SongsterrRevisionTrackInput {
   trackMeta: SongsterrStateMetaCurrentTrack;
@@ -230,7 +231,10 @@ export class SongsterrToAlphaTabConverter {
     score.finish(settings);
 
     const exporter = new alphaTab.exporter.Gp7Exporter();
-    const data = exporter.export(score, settings);
+    // alphaTab omits <Fret>/<Midi> on percussion notes, which Guitar Pro needs
+    // to place them on the drum staff — patch them back in (no-op for
+    // guitar-only files).
+    const data = patchGp7Percussion(exporter.export(score, settings));
 
     return { data, warnings };
   }


### PR DESCRIPTION
## What

GP7 files exported with drum tracks open as **empty** in Guitar Pro. Guitar Pro only places a percussion note on the drum staff when the note carries `<Fret>`/`<Midi>` properties, and alphaTab's `Gp7Exporter` writes those only for stringed notes — every exported percussion note was silently dropped.

## Fix

After export, the converter post-processes the GPIF (the XML inside the GP7 zip) and injects

```xml
<Property name="Fret"><Fret>{midi}</Fret></Property>
<Property name="Midi"><Number>{midi}</Number></Property>
```

into every percussion note, where `{midi}` is the drum sound's MIDI number from the drum kit articulation's `OutputMidiNumber`. Guitar-only files are untouched — the pass is a byte-identical no-op when no `drumKit` instrument set is present.

- Adds `fflate` (tiny, zero-dep) for the GP7 zip read/rewrite.
- New module `src/lib/server/services/converter/gp7-percussion-patch.ts`.
- Regression test asserting every percussion note in an exported GP7 carries `Fret`/`Midi` equal to its drum sound's MIDI number (kick 36 / snare 38 / hi-hat 42).

## Validation

Verified against a real Songsterr song ("You Won't Relent" — Jesus Culture, drums track): all 3,271 percussion notes now carry the properties with correct drum MIDI numbers (36, 38, 41, 42, 44, 45, 49, 51), and a guitar-only export is byte-identical to before. The patched file re-imports cleanly with alphaTab. Full test suite passes (38 tests) and `svelte-check` is clean.

## Upstream note

The root cause is in `@coderline/alphatab`'s `Gp7Exporter`. It has since been fixed on alphaTab's `develop` branch (CoderLine/alphaTab#2591, refined in #2832) but is **unreleased** — the bug is present in the pinned `1.8.1` and the latest published `1.8.4`. This patch ships the fix now and can be dropped once the dependency is bumped to a release that includes it.
